### PR TITLE
restart reads on EINTR

### DIFF
--- a/gcodefeeder/feeder.go
+++ b/gcodefeeder/feeder.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -131,6 +132,9 @@ func (f *Feeder) read(ctx context.Context) {
 		default:
 			buf, _, err := f.reader.ReadLine()
 			if err != nil {
+				if err == syscall.EINTR {
+					continue
+				}
 				log.Errorf("Feeder: Error reading from printer: %v", err)
 				f.status = Error
 				return


### PR DESCRIPTION
Restart device reads on interrupted system calls. Fixes #9

Per [Go 1.14 release notes](https://golang.org/doc/go1.14#runtime), 

> A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases. This means that programs that use packages like syscall or golang.org/x/sys/unix will see more slow system calls fail with EINTR errors. Those programs will have to handle those errors in some way, most likely looping to try the system call again. For more information about this see man 7 signal for Linux systems or similar documentation for other systems.

Restarting system calls on EINTR is a common practice in UNIX programming, and is cited in many books as an example of "less is better" compromise.