### PR TITLE
[feeder] lock tty.Close to prevent panic

### DIFF
--- a/gcodefeeder/feeder.go
+++ b/gcodefeeder/feeder.go
@@ -5,13 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"go.bug.st/serial"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"go.bug.st/serial"
 )
 
 type Status int
@@ -59,6 +61,7 @@ type Feeder struct {
 	reader         *bufio.Reader
 	progressRegexp *regexp.Regexp
 
+	sync.Mutex
 	cancelFunc context.CancelFunc
 }
 
@@ -85,6 +88,8 @@ func NewFeeder(deviceName, fileName string) (*Feeder, error) {
 }
 
 func (f *Feeder) Cancel() {
+	f.Lock()
+	defer f.Unlock()
 	log.Debug("Feeder: Cancel is called")
 	f.cancelFunc()
 	//  turn off temperature


### PR DESCRIPTION
We see log entry like this before the crash:
```
time="2022-12-15T08:29:56-08:00" level=debug msg="Feeder: WRITING: G1 X144.232 Y87.198 E0.01151"
time="2022-12-15T08:29:56-08:00" level=debug msg="Feeder: Cancel is called"
time="2022-12-15T08:29:56-08:00" level=debug msg="Feeder: Cancel is called"
time="2022-12-15T08:29:57-08:00" level=debug msg="Started http server on [::1]:8888"
time="2022-12-15T08:29:58-08:00" level=info msg="Received info handler request"
```
Matching with:
```
2022-12-15T08:29:56.794967-08:00 Process '/usr/bin/3djuggler' exited normally with status 2
2022-12-15T08:29:56.794998-08:00 Sleeping for 1 seconds before restarting /usr/bin/3djuggler
2022-12-15T08:29:57.795132-08:00 Starting process: /usr/bin/3djuggler
2022-12-15T08:29:57.796790-08:00 Waiting for /usr/bin/3djuggler to stop
```

We have a crash because `Cancel()` is called 2 times (from write and read routine) and tty.Close happens during the Write/Read.
Unfortunately implementation of serial doesn't look to be a [thread safe](https://github.com/bugst/go-serial/blob/adc54fb194a0b4327132ea44610a8e731bae4a3b/unixutils/pipe.go#L53-L55).