### PR TITLE
No need for a temporary job file; make it Windows-ready

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
+	"strings"
 	"time"
 
 	"github.com/leoleovich/3djuggler/gcodefeeder"
@@ -15,7 +15,6 @@ import (
 
 type Daemon struct {
 	config     *Config
-	jobfile    string
 	job        *juggler.Job
 	ie         *InternEndpoint
 	feeder     *gcodefeeder.Feeder
@@ -105,15 +104,10 @@ func (daemon *Daemon) Start() {
 
 			log.Info("Sending to printer")
 			log.Debug("FileSize: ", len(daemon.job.FileContent))
-			err := os.WriteFile(daemon.jobfile, []byte(daemon.job.FileContent), 0644)
-			if err != nil {
-				log.Error(err)
-				break
-			}
 
 			daemon.feeder, err = gcodefeeder.NewFeeder(
 				daemon.config.Serial,
-				daemon.jobfile,
+				strings.NewReader(daemon.job.FileContent),
 			)
 			if err != nil {
 				log.Error("Failed to create Feeder: ", err)
@@ -232,7 +226,8 @@ func (daemon *Daemon) StartHandler(w http.ResponseWriter, _ *http.Request) {
 	// Add headers to allow AJAX
 	juggler.SetHeaders(w)
 
-	if daemon.job.Status == juggler.StatusWaitingButton {
+	switch daemon.job.Status {
+	case juggler.StatusWaitingButton:
 		// Initial start
 		daemon.UpdateStatus(juggler.StatusSending)
 		for daemon.job.Status != juggler.StatusSending {
@@ -240,7 +235,7 @@ func (daemon *Daemon) StartHandler(w http.ResponseWriter, _ *http.Request) {
 			time.Sleep(1 * time.Second)
 		}
 		return
-	} else if daemon.job.Status == juggler.StatusPaused {
+	case juggler.StatusPaused:
 		// Unpause
 		daemon.feeder.Start()
 		daemon.UpdateStatus(juggler.StatusPrinting)

--- a/gcodefeeder/examples/client.go
+++ b/gcodefeeder/examples/client.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"os"
+	"strings"
+	"time"
+
 	"github.com/leoleovich/3djuggler/gcodefeeder"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"time"
 )
 
 func main() {
@@ -13,7 +15,7 @@ func main() {
 
 	feeder, _ := gcodefeeder.NewFeeder(
 		"/dev/tty.usbmodem14601",
-		"/Users/leoleovich/3d/M5.0_Nut_0.3mm_PLA_MK3.gcode",
+		strings.NewReader("M140 S0\nM104 S0\nM107\nM84 X Y E\n"),
 	)
 	go func() {
 		for {

--- a/gcodefeeder/feeder.go
+++ b/gcodefeeder/feeder.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"regexp"
 	"strconv"
 	"strings"
@@ -51,7 +51,7 @@ func (s Status) String() string {
 
 type Feeder struct {
 	deviceName string
-	fileName   string
+	gcode      io.Reader
 	printerAck chan bool
 	progress   int
 	status     Status
@@ -65,10 +65,10 @@ type Feeder struct {
 	cancelFunc context.CancelFunc
 }
 
-func NewFeeder(deviceName, fileName string) (*Feeder, error) {
+func NewFeeder(deviceName string, gcode io.Reader) (*Feeder, error) {
 	f := Feeder{
 		deviceName:     deviceName,
-		fileName:       fileName,
+		gcode:          gcode,
 		printerAck:     make(chan bool),
 		progressRegexp: regexp.MustCompile("M73 P([0-9]+).*"),
 	}
@@ -79,11 +79,6 @@ func NewFeeder(deviceName, fileName string) (*Feeder, error) {
 		return nil, fmt.Errorf("failed to connect to %s: %w", deviceName, err)
 	}
 	f.status = Ready
-
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed to open %s: %w", fileName, err)
-	}
-
 	return &f, nil
 }
 
@@ -211,7 +206,7 @@ func (f *Feeder) write(ctx context.Context, command string) error {
 	case <-f.printerAck:
 		break
 	case <-ctx.Done():
-		return errors.New("Context is Done")
+		return errors.New("context is Done")
 	}
 	return nil
 }
@@ -235,27 +230,20 @@ func (f *Feeder) Feed() error {
 	<-f.printerAck
 	f.Start()
 
-	file, err := os.Open(f.fileName)
-	if err != nil {
-		f.status = Error
-		return err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(f.gcode)
 	for scanner.Scan() {
 		line := scanner.Text()
 		for f.status == ManuallyPaused {
 			select {
 			case <-ctx.Done():
-				return errors.New("Context is Done")
+				return errors.New("context is Done")
 			default:
 				time.Sleep(5 * time.Second)
 				log.Info("Feeder: paused manually")
 			}
 		}
 		f.status = Printing
-		err = f.write(ctx, line)
+		err := f.write(ctx, line)
 		if err != nil {
 			f.status = Error
 			return err

--- a/internendpoint.go
+++ b/internendpoint.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/leoleovich/3djuggler/gcodefeeder"
-	"github.com/leoleovich/3djuggler/juggler"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/leoleovich/3djuggler/gcodefeeder"
+	"github.com/leoleovich/3djuggler/juggler"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -162,7 +163,7 @@ func (ie *InternEndpoint) getJob(id int) error {
 	ie.job = result.Content
 
 	if ie.job.ID == 0 {
-		return errors.New("Nothing to print")
+		return errors.New("nothing to print")
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -4,15 +4,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/leoleovich/3djuggler/juggler"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"time"
+
+	"github.com/leoleovich/3djuggler/juggler"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
-	jobfile                  = "/tmp/job"
 	waitingForButtonInterval = 10 * time.Minute
 	pollingInterval          = 5 * time.Second
 	defaultListen            = "[::1]:8888"
@@ -88,8 +88,6 @@ func main() {
 	if daemon.config.Serial == "" {
 		daemon.config.Serial = defaultSerial
 	}
-
-	daemon.jobfile = jobfile
 
 	daemon.ie = &InternEndpoint{
 		APIApp: daemon.config.InternEndpoint.APIApp,


### PR DESCRIPTION
No need for a temporary job file, simply pass the job which is already in memory as an io.Reader.

This also makes it Windows-ready.

Tested with Creality CR-10 V2 on a Windows laptop.

```
time="2025-09-25T18:39:22+01:00" level=info msg="My status is: 'Waiting for a button'"
time="2025-09-25T18:39:22+01:00" level=info msg="Job 32676 is waiting"
time="2025-09-25T18:39:23+01:00" level=info msg="Job status on intern: Waiting for a button"
time="2025-09-25T18:39:23+01:00" level=info msg="Waiting 590 more seconds for somebody to press the button"
time="2025-09-25T18:39:23+01:00" level=info msg="Received start handler request"
time="2025-09-25T18:39:23+01:00" level=info msg="Waiting for Sending to printer status to be set"
time="2025-09-25T18:39:24+01:00" level=info msg="Waiting for Sending to printer status to be set"
time="2025-09-25T18:39:25+01:00" level=info msg="Waiting for Sending to printer status to be set"
time="2025-09-25T18:39:26+01:00" level=info msg="Waiting for Sending to printer status to be set"
time="2025-09-25T18:39:27+01:00" level=info msg="Waiting for Sending to printer status to be set"
time="2025-09-25T18:39:27+01:00" level=info msg="Updating intern status to 'Sending to printer'"
time="2025-09-25T18:39:28+01:00" level=info msg="My status is: 'Sending to printer'"
time="2025-09-25T18:39:28+01:00" level=info msg="Sending to printer"
time="2025-09-25T18:39:32+01:00" level=info msg="Updating intern status to 'Printing... (0.0%)'"
time="2025-09-25T18:39:33+01:00" level=info msg="My status is: 'Printing'"
time="2025-09-25T18:39:33+01:00" level=info msg="Job 32676 is currently printing"
time="2025-09-25T18:39:34+01:00" level=info msg="Updating intern status to 'Printing... (0.0%)'"
time="2025-09-25T18:39:37+01:00" level=info msg="My status is: 'Printing'"
```