### PR TITLE
Add validation and different pause handling

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -105,6 +105,12 @@ func (daemon *Daemon) Start() {
 			log.Info("Sending to printer")
 			log.Debug("FileSize: ", len(daemon.job.FileContent))
 
+			if err = gcodefeeder.ValidateGcode(strings.NewReader(daemon.job.FileContent)); err != nil {
+				log.Errorf("Gcode validation failed: %v", err)
+				daemon.UpdateStatus(juggler.StatusCancelling)
+				break
+			}
+
 			daemon.feeder, err = gcodefeeder.NewFeeder(
 				daemon.config.Serial,
 				strings.NewReader(daemon.job.FileContent),

--- a/daemon.go
+++ b/daemon.go
@@ -235,15 +235,6 @@ func (daemon *Daemon) StartHandler(w http.ResponseWriter, _ *http.Request) {
 			time.Sleep(1 * time.Second)
 		}
 		return
-	case juggler.StatusPaused:
-		// Unpause
-		daemon.feeder.Start()
-		daemon.UpdateStatus(juggler.StatusPrinting)
-		for daemon.job.Status != juggler.StatusPrinting {
-			log.Infof("Waiting for %s status to be set", juggler.StatusPrinting)
-			time.Sleep(1 * time.Second)
-		}
-		return
 	}
 
 	errS := fmt.Sprintf("Ignore buttonpress in '%v' status", daemon.job.Status)

--- a/gcodefeeder/feeder.go
+++ b/gcodefeeder/feeder.go
@@ -233,20 +233,13 @@ func (f *Feeder) Feed() error {
 	scanner := bufio.NewScanner(f.gcode)
 	for scanner.Scan() {
 		line := scanner.Text()
-		for f.status == ManuallyPaused {
-			select {
-			case <-ctx.Done():
-				return errors.New("context is Done")
-			default:
-				time.Sleep(5 * time.Second)
-				log.Info("Feeder: paused manually")
-			}
-		}
-		f.status = Printing
 		err := f.write(ctx, line)
 		if err != nil {
 			f.status = Error
 			return err
+		}
+		if f.status == ManuallyPaused {
+			f.status = Printing
 		}
 	}
 	f.status = Finished
@@ -254,7 +247,19 @@ func (f *Feeder) Feed() error {
 }
 
 func (f *Feeder) Pause() {
+	f.Lock()
+	defer f.Unlock()
+
 	f.status = ManuallyPaused
+
+	_, err := f.writer.Write([]byte("M601\n"))
+	if err != nil {
+		log.Errorf("Feeder: Error writing pause command: %v", err)
+		return
+	}
+	if err := f.writer.Flush(); err != nil {
+		log.Errorf("Feeder: Error flushing pause command: %v", err)
+	}
 }
 
 func (f *Feeder) Start() {

--- a/gcodefeeder/validate.go
+++ b/gcodefeeder/validate.go
@@ -1,0 +1,44 @@
+package gcodefeeder
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const maxNozzleTemp = 220
+
+var nozzleTempRegexp = regexp.MustCompile(`^M10[49]\b`)
+
+func ValidateGcode(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if idx := strings.Index(line, ";"); idx >= 0 {
+			line = line[:idx]
+		}
+		if !nozzleTempRegexp.MatchString(line) {
+			continue
+		}
+		temp, ok := parseSParam(line)
+		if ok && temp > maxNozzleTemp {
+			return errors.New("too high temperature set, please use PLA presets only")
+		}
+	}
+	return scanner.Err()
+}
+
+func parseSParam(line string) (int, bool) {
+	for _, field := range strings.Fields(line) {
+		if strings.HasPrefix(field, "S") || strings.HasPrefix(field, "s") {
+			val, err := strconv.Atoi(field[1:])
+			if err == nil {
+				return val, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/gcodefeeder/validate_test.go
+++ b/gcodefeeder/validate_test.go
@@ -1,0 +1,67 @@
+package gcodefeeder
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateGcode(t *testing.T) {
+	tests := []struct {
+		name    string
+		gcode   string
+		wantErr bool
+	}{
+		{
+			name:    "safe temperature",
+			gcode:   "M104 S200\nG28\n",
+			wantErr: false,
+		},
+		{
+			name:    "exactly at limit",
+			gcode:   "M104 S220\nG28\n",
+			wantErr: false,
+		},
+		{
+			name:    "M104 over limit",
+			gcode:   "M104 S250\nG28\n",
+			wantErr: true,
+		},
+		{
+			name:    "M109 over limit",
+			gcode:   "G28\nM109 S260\n",
+			wantErr: true,
+		},
+		{
+			name:    "temperature in comment ignored",
+			gcode:   "; M104 S300\nG28\n",
+			wantErr: false,
+		},
+		{
+			name:    "no temperature commands",
+			gcode:   "G28\nG1 X10 Y10\n",
+			wantErr: false,
+		},
+		{
+			name:    "bed temperature ignored",
+			gcode:   "M140 S300\nG28\n",
+			wantErr: false,
+		},
+		{
+			name:    "inline comment with high temp",
+			gcode:   "M104 S250 ; set temp\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGcode(strings.NewReader(tt.gcode))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateGcode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && err.Error() != "too high temperature set, please use PLA presets only" {
+				t.Errorf("unexpected error message: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For pause handling -> the printer should keep the stream blocked until the button is pressed on the printer, so all we need to do is send M601 code for firmware routine. Pressing button on printer should resume communication. Hopefully it's better handling without timeouts of serial communication.

For gcode nozzle temp validation -> you can in theory still change it on the device but it is as good as it gets -> we will be limiting the temperatures set to 220 temperatures if you ar esubmitting the gcode.