### PR TITLE
Report the build commit from the toolchain instead of an ldflag

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ and nobody can hold a printer they are not standing next to.
 go build ./...
 ```
 
-To populate `/version`, stamp the commit at build time:
-
-```sh
-go build -ldflags "-X main.gitCommit=$(git rev-parse --short HEAD)" .
-```
+`/version` reports the commit the binary was built from. The Go toolchain
+records it automatically, so there is nothing to pass at build time. Building
+from a tree with uncommitted changes appends `-dirty`.
 
 Cross-compiling for the device is a normal Go cross-compile:
 

--- a/daemon.go
+++ b/daemon.go
@@ -457,11 +457,11 @@ func (daemon *Daemon) PauseHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-// VersionHandler reports the git commit this daemon was built from
+// VersionHandler reports the commit this daemon was built from
 func (daemon *Daemon) VersionHandler(w http.ResponseWriter, _ *http.Request) {
 	log.Infof("Received version handler request")
 	// Add headers to allow AJAX
 	juggler.SetHeaders(w)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(w, gitCommit)
+	fmt.Fprint(w, version())
 }

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -146,17 +146,24 @@ func TestInfoHandlerFieldNames(t *testing.T) {
 }
 
 func TestVersionHandler(t *testing.T) {
-	orig := gitCommit
-	gitCommit = "abc123"
-	t.Cleanup(func() { gitCommit = orig })
-
 	d := newTestDaemon(juggler.StatusWaitingJob)
 	w := doRequest(d, "/version")
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
-	if got := strings.TrimSpace(w.Body.String()); got != "abc123" {
-		t.Errorf("body = %q, want abc123", got)
+	if ct := w.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/plain; charset=utf-8", ct)
+	}
+	// The commit comes from the build, so the value depends on how the test
+	// binary was produced. It must always report something.
+	if got := strings.TrimSpace(w.Body.String()); got == "" {
+		t.Error("/version returned an empty body")
+	}
+}
+
+func TestVersionIsReported(t *testing.T) {
+	if got := version(); got == "" {
+		t.Error("version() returned an empty string")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/leoleovich/3djuggler/juggler"
@@ -16,9 +17,44 @@ var (
 	pollingInterval          = 5 * time.Second
 	defaultListen            = "[::1]:8888"
 	defaultSerial            = "/dev/ttyACM0"
-	// Set during compilation to export version via /version http handler
-	gitCommit = ""
 )
+
+// version reports the commit this binary was built from, which the Go
+// toolchain records automatically. Nothing needs to be passed at build time.
+func version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	return versionFromSettings(info.Settings)
+}
+
+// versionFromSettings renders the build settings the toolchain recorded. It is
+// separate from version so it can be tested: a test binary is a synthesised
+// main package and does not reliably carry VCS metadata of its own.
+func versionFromSettings(settings []debug.BuildSetting) string {
+	var revision string
+	var modified bool
+	for _, setting := range settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+
+	if revision == "" {
+		return "unknown"
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	if modified {
+		revision += "-dirty"
+	}
+	return revision
+}
 
 type InternEndpoint struct {
 	APIApp      string `json:"api_app"`

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"runtime/debug"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -13,4 +14,66 @@ import (
 func TestMain(m *testing.M) {
 	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
+}
+
+func TestVersionFromSettings(t *testing.T) {
+	const full = "2d3503b7df25000000000000000000000000000a"
+
+	tests := []struct {
+		name     string
+		settings []debug.BuildSetting
+		want     string
+	}{
+		{
+			name:     "revision is truncated to twelve characters",
+			settings: []debug.BuildSetting{{Key: "vcs.revision", Value: full}},
+			want:     "2d3503b7df25",
+		},
+		{
+			name: "a modified tree is marked dirty",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: full},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			want: "2d3503b7df25-dirty",
+		},
+		{
+			name: "an unmodified tree is not marked dirty",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: full},
+				{Key: "vcs.modified", Value: "false"},
+			},
+			want: "2d3503b7df25",
+		},
+		{
+			name:     "a revision shorter than the limit is left alone",
+			settings: []debug.BuildSetting{{Key: "vcs.revision", Value: "abc123"}},
+			want:     "abc123",
+		},
+		{
+			name:     "no settings at all",
+			settings: nil,
+			want:     "unknown",
+		},
+		{
+			name:     "settings without a revision",
+			settings: []debug.BuildSetting{{Key: "vcs.modified", Value: "true"}},
+			want:     "unknown",
+		},
+		{
+			// Guards against the key being misspelled or renamed: the value
+			// is present but under a key we do not read.
+			name:     "revision under an unrecognised key is ignored",
+			settings: []debug.BuildSetting{{Key: "vcs.rev", Value: full}},
+			want:     "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := versionFromSettings(tt.settings); got != tt.want {
+				t.Errorf("versionFromSettings() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
/version needed -ldflags "-X main.gitCommit=..." to say anything, so a plain go build produced a binary that reported nothing. Every build path had to remember the flag, and none of them did.

Since 1.18 the toolchain records the commit itself, so read it back with debug.ReadBuildInfo instead. `go build .` is now enough, and a binary built from a tree with uncommitted changes reports the commit with -dirty appended, which the injected variable could never express.

The handler test no longer sets the commit by hand, because there is no variable to set: it checks that /version reports something and serves it as text.